### PR TITLE
Consider return type and arguments for creating functions #3

### DIFF
--- a/addons/nhb_functions_on_the_fly/lib/class-finder.gd
+++ b/addons/nhb_functions_on_the_fly/lib/class-finder.gd
@@ -1,0 +1,60 @@
+## This script will find a custom class based on its class_name.
+## If a script was found, its script path will be returned.
+## If no script is found within {CANCEL_AFTER_MS} ms, an empty string is returned.
+class_name NhbFunctionsOnTheFlyClassFinder
+extends Node
+
+
+const CANCEL_AFTER_MS = 3000
+
+
+var _found_path: String
+
+
+func get_found_path() -> String:
+    return _found_path
+
+
+func find_class_path(name_of_class : String) -> String:
+    var dir = DirAccess.open("res://")
+    if not dir:
+        return ""
+
+    var start_ms = Time.get_ticks_msec()
+    _search_dir(dir, name_of_class, start_ms)
+
+    return _found_path
+
+
+func _search_dir(dir : DirAccess, target : String, start_ms : int):
+    if Time.get_ticks_msec() - start_ms > 3000:
+        _found_path = ""
+        return
+
+    for item in dir.get_files():
+        if !item.ends_with(".gd"): continue
+
+        var path = dir.get_current_dir() + "/" + item
+        var file = FileAccess.open(path, FileAccess.READ)
+        if !file:
+            continue
+
+        while not file.eof_reached():
+            if Time.get_ticks_msec() - start_ms > CANCEL_AFTER_MS:
+                _found_path = ""
+                return
+            var line = file.get_line()
+            if line.begins_with("class_name "):
+                var parts = line.split(" ")
+                if parts.size() > 1 and parts[1] == target:
+                    _found_path = path
+                    return
+        file.close()
+
+    for sub in dir.get_directories():
+        dir.change_dir(sub)
+        _search_dir(dir, target, start_ms)
+
+        if _found_path != "": return
+
+        dir.change_dir("..")

--- a/addons/nhb_functions_on_the_fly/lib/class-finder.gd.uid
+++ b/addons/nhb_functions_on_the_fly/lib/class-finder.gd.uid
@@ -1,0 +1,1 @@
+uid://c8db7kbdv62j0

--- a/test/unit/test_plugin.gd
+++ b/test/unit/test_plugin.gd
@@ -339,6 +339,18 @@ func test_find_signal_declaration_parameters_with_native_signals():
     code_edit.free()
 
 
+#func test_find_signal_declaration_parameters_with_custom_signals():
+#    var utils = NhbFunctionsOnTheFlyUtils.new()
+#    var code_edit = CodeEdit.new()
+#
+#    code_edit.set_line(0, "var my_custom_class: CustomClassWithSignal\n")
+#    code_edit.set_line(1, "my_custom_class.custom_signal.connect(_on_custom_signal)")
+#    assert_eq(utils.find_signal_declaration_parameters(1, code_edit.get_line(1), code_edit), "text: String, number: int")
+#
+#    utils.free()
+#    code_edit.free()
+
+
 ## Unfortunately it's not possible to get an EditorSettings instance for now.
 ## Uncomment this test as soon as it's possible.
 # func test_get_indentation_character():


### PR DESCRIPTION
Concerning #3

- Implement the following cases
    - [x] **signal without arguments**: `my_button.pressed.connect(_on_pressed)`
    - [x] **signal with arguments**: `my_area.body_entered.connect(_on_body_entered)`
    - [x] **variable with return type**: `my_string = _get_my_string()`
    - [x] **custom signals with arguments**: my_custom_class.custom_signal.connect(_on_custom_signal)
- [x] Write unit tests

Unfortunately it's not so easy to get a default return value based on the object type (example: "Vector2.ZERO" for `Vector2`). So I had to implement a static list at `NhbFunctionsOnTheFlyUtils::get_return_value_by_return_type()`.
