### PR TITLE
Include the nhb_functions_on_the_fly addons dir in releases again

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,7 +4,7 @@
 # Only include the addons folder when downloading from the Asset Library.
 /**        export-ignore
 /addons    !export-ignore
-/addons/nhb_functions_on_the_fly/** export-ignore
+/addons/nhb_functions_on_the_fly/** !export-ignore
 
 # Keep essential files in export
 /LICENSE.md !export-ignore


### PR DESCRIPTION
The addon code was missing in the releases since 1.0.1, this should include it again.

Wanted to use this in a project, but no code was there when adding it using the AssetLib.